### PR TITLE
MAINT: remove usage of xrange. Closes  #29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
 env:
   - WITH_MPI=no
   - WITH_MPI=yes MPI4PY_VERSION=3.0.3

--- a/NuMPI/Optimization/linesearch.py
+++ b/NuMPI/Optimization/linesearch.py
@@ -43,8 +43,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
 
 import numpy as np
 from warnings import warn
-from scipy._lib.six import xrange
-
 
 class LineSearchWarning(RuntimeWarning):
     pass
@@ -132,7 +130,7 @@ def scalar_search_wolfe2(phi_derphi, phi0=None,
     if extra_condition is None:
         extra_condition = lambda alpha, phi: True
 
-    for i in xrange(maxiter):
+    for i in range(maxiter):
         if alpha1 == 0 or (amax is not None and alpha0 == amax):
             # alpha1 == 0: This shouldn't happen. Perhaps the increment has
             # slipped below machine precision?

--- a/tests/test_LBFGS_minimization_problems.py
+++ b/tests/test_LBFGS_minimization_problems.py
@@ -36,14 +36,12 @@ import pytest
 def test_analytical_min(Objective,n):
     """
     Compares the result with the analyticaly known posistion of the minimum
-    :return:
     """
 
     x0 = Objective.startpoint(n)
 
     res = LBFGS(Objective.f, x0, jac=Objective.grad, maxcor=5, gtol=1e-6, maxiter=1000)
-    print(np.reshape(res.x, (-1,)))
-    #np.testing.assert_almost_equal( res.x,Objective.xmin(n))
+
     np.testing.assert_allclose(np.reshape(res.x, (-1,)), np.reshape(Objective.xmin(n),(-1,)), rtol=1e-6)
 
 @pytest.mark.parametrize("Objective",[mp.Trigonometric])

--- a/tests/test_LBFGS_minimization_problems.py
+++ b/tests/test_LBFGS_minimization_problems.py
@@ -42,9 +42,9 @@ def test_analytical_min(Objective,n):
     x0 = Objective.startpoint(n)
 
     res = LBFGS(Objective.f, x0, jac=Objective.grad, maxcor=5, gtol=1e-6, maxiter=1000)
-
+    print(np.reshape(res.x, (-1,)))
     #np.testing.assert_almost_equal( res.x,Objective.xmin(n))
-    np.testing.assert_allclose(np.reshape(res.x, (-1,)), np.reshape(Objective.xmin(n),(-1,)), rtol=1e-7)
+    np.testing.assert_allclose(np.reshape(res.x, (-1,)), np.reshape(Objective.xmin(n),(-1,)), rtol=1e-6)
 
 @pytest.mark.parametrize("Objective",[mp.Trigonometric])
 @pytest.mark.parametrize("n",[10,30])


### PR DESCRIPTION
Now NuMPI should be compatible with scipy 1.5.0