### PR TITLE
Bug/ci net cdf installation

### DIFF
--- a/.travis.before_install.bash
+++ b/.travis.before_install.bash
@@ -8,5 +8,6 @@ python -m pip install $(grep numpy requirements.txt)
 if [ "$WITH_MPI" == "yes" ]; then
   python -m pip install --no-binary mpi4py mpi4py==${MPI4PY_VERSION}
   BUILDDIR=/tmp PREFIX=$HOME/.local source .install_parallel_netcdf.sh
-  sed -n '/netCDF4/!p' requirements.txt > requirements.txt # remove from requirements since we already installed it
+  sed -n '/netCDF4/!p' requirements.txt > requirements_temp.txt # remove from requirements since we already installed it
+  mv requirements_temp.txt requirements.txt
 fi

--- a/.travis.before_install.bash
+++ b/.travis.before_install.bash
@@ -8,4 +8,5 @@ python -m pip install $(grep numpy requirements.txt)
 if [ "$WITH_MPI" == "yes" ]; then
   python -m pip install --no-binary mpi4py mpi4py==${MPI4PY_VERSION}
   BUILDDIR=/tmp PREFIX=$HOME/.local source .install_parallel_netcdf.sh
+  sed -n '/netCDF4/!p' requirements.txt > requirements.txt # remove from requirements since we already installed it
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
 before_install:
   - source .travis.before_install.bash
 install:
-  - source .print_netcdf_capabilities.sh
-  - cat requirements.txt
   - python -m pip install --upgrade -r requirements.txt --no-binary setuptools_scm
   - source .print_netcdf_capabilities.sh
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - source .travis.before_install.bash
 install:
   - source .print_netcdf_capabilities.sh
-  - python -m pip install --upgrade --upgrade-strategy "only-if-needed" -r requirements.txt --no-binary setuptools_scm
+  - python -m pip install --upgrade -r requirements.txt --no-binary setuptools_scm
   - source .print_netcdf_capabilities.sh
   - python setup.py install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - source .travis.before_install.bash
 install:
   - source .print_netcdf_capabilities.sh
-  - python -m pip install --upgrade -r requirements.txt --no-binary setuptools_scm
+  - python -m pip install --upgrade --upgrade-strategy "only-if-needed" -r requirements.txt --no-binary setuptools_scm
   - source .print_netcdf_capabilities.sh
   - python setup.py install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 dist: focal
 language: python
 python:
-  - 3.6
   - 3.7
   - 3.8
+  - 3.9
 env:
   - WITH_MPI=no
   - WITH_MPI=yes MPI4PY_VERSION=3.0.3 HDF5_VERSION=1.12.0 PNETCDF_VERSION=1.12.2 NETCDF4_VERSION=4.7.4 NETCDF4_PYTHON_VERSION=1.5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 install:
   - source .print_netcdf_capabilities.sh
   - python -m pip install --upgrade -r requirements.txt --no-binary setuptools_scm
+  - python-m pip install runtests
   - source .print_netcdf_capabilities.sh
   - python setup.py install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
 before_install:
   - source .travis.before_install.bash
 install:
+  - source .print_netcdf_capabilities.sh
   - python -m pip install --upgrade -r requirements.txt --no-binary setuptools_scm
   - source .print_netcdf_capabilities.sh
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
   - source .travis.before_install.bash
 install:
   - source .print_netcdf_capabilities.sh
+  - cat requirements.txt
   - python -m pip install --upgrade -r requirements.txt --no-binary setuptools_scm
-  - python-m pip install runtests
   - source .print_netcdf_capabilities.sh
   - python setup.py install
 script:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,13 @@
 Change log for NuMPI
 ===================
 
+v0.1.6 (22Jun21)
+----------------
+
+- ENH: Optimization: parallelized the bound constrained conjugate gradient without restart
+- ENH: Optimization: implement bound constrained conjugate gradient without restart when the constrained set changes
+- ENH: Optimization: implement bound constrained conjugate gradient with restart when the constrained set changes
+
 v0.1.5 (02Mar21)
 ----------------
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,13 @@
 Change log for NuMPI
 ===================
 
+v0.1.7 (22Jun21)
+----------------
+
+- Drop support for python3.6 and take python3.9 in testing
+- Fix bug in CI installation 
+
+
 v0.1.6 (22Jun21)
 ----------------
 


### PR DESCRIPTION
What happend: 

In .travis.yml
```yml
before_install:
  - source .travis.before_install.bash  # installs NetCDF with parallel capabilities, including the python package (--no-binary etc...)
install:
  - source .print_netcdf_capabilities.sh   # Output:  NetCDF has parallel capabilities 
  - python -m pip install --upgrade  -r requirements.txt --no-binary setuptools_scm   # pip reinstalls the netCDF package
  - source .print_netcdf_capabilities.sh  # Output:  NetCDF has no  parallel capabilities anymore
  - python setup.py install
```

I tried
```yml
python -m pip install --upgrade --upgrade-strategy "only-if-needed" -r requirements.txt --no-binary setuptools_scm
```
But it still reinstalled netCDF

Finally I ended up removing the netCDF line on the fly in requirements using sed.
I don't now what changed today for this new behaviour of pip.

