### PR TITLE
Add results when line-search failed, fix store iterate, add norms

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,8 +68,8 @@ jobs:
           if [ "${{ matrix.mpi }}" == "yes" ]; then
             for nbprocs in 1 2 4 8 10; do
               echo "=== $nbprocs MPI processes ==="
-              mpirun --oversubscribe -n $nbprocs python3 --full-trace
+              mpirun --oversubscribe -n $nbprocs python3 -m pytest --verbose --full-trace
             done
           else
-            python3 -m pytest --full-trace -s
+            python3 -m pytest --verbose --full-trace -s
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,8 +68,8 @@ jobs:
           if [ "${{ matrix.mpi }}" == "yes" ]; then
             for nbprocs in 1 2 4 8 10; do
               echo "=== $nbprocs MPI processes ==="
-              mpirun --oversubscribe -n $nbprocs python3 --verbose --full-trace
+              mpirun --oversubscribe -n $nbprocs python3 --full-trace
             done
           else
-            python3 -m pytest --verbose --full-trace -s
+            python3 -m pytest --full-trace -s
           fi

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 Change log for NuMPI
 ===================
 
-v0.7.2 (25Mar25)
+v0.7.2 (26Mar25)
 ----------------
 
 - BUG: Fixed parallel write into NPY files when a subdomain is only a single

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ Change log for NuMPI
 v0.7.2 (26Mar25)
 ----------------
 
+- API: Allow passing communicator directly to `l_bfgs`
 - BUG: Fixed parallel write into NPY files when a subdomain is only a single
   grid point in one dimension
 - MAINT: Return last result when the line search fails

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,13 @@
 Change log for NuMPI
 ===================
 
+v0.7.2 (25Mar25)
+----------------
+
+- BUG: Fixed parallel write into NPY files when a subdomain is only a single
+  grid point in one dimension
+- MAINT: Throw proper errors and report convergence
+
 v0.7.1 (18Mar25)
 ----------------
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ v0.7.2 (25Mar25)
 
 - BUG: Fixed parallel write into NPY files when a subdomain is only a single
   grid point in one dimension
+- MAINT: Return last result when the line search fails
 - MAINT: Throw proper errors and report convergence
 
 v0.7.1 (18Mar25)

--- a/NuMPI/Optimization/LBFGS.py
+++ b/NuMPI/Optimization/LBFGS.py
@@ -27,7 +27,6 @@ import logging
 
 import numpy as np
 
-from .. import MPI
 from ..Tools import Reduction
 from .LineSearch import scalar_search_wolfe2
 from .Result import OptimizeResult
@@ -92,7 +91,8 @@ def l_bfgs(
     maxls=20,
     linesearch_options=dict(c1=1e-3, c2=0.9),
     disp=None,
-    comm=MPI.COMM_WORLD,
+    pnp=None,
+    comm=None,
     store_iterates=None,
     callback=None,
     **options,
@@ -133,6 +133,8 @@ def l_bfgs(
         A dictionary with optional settings for the line search parameters.
     disp : int, optional
         If disp is a positive integer, convergence messages will be printed.
+    pnp : Reduction, optional
+        Reduction class (or numpy module).
     comm : MPI.Comm, optional
         MPI communicator.
     store_iterates : bool, optional
@@ -154,7 +156,13 @@ def l_bfgs(
     # but we will work with the shape (-1, 1)
     original_shape = x.shape
 
-    pnp = Reduction(comm)
+    if comm:
+        if pnp:
+            raise RuntimeError("Please specify either `comm` or `pnp`, not both.")
+        pnp = Reduction(comm)
+    else:
+        if not pnp:
+            pnp = np
 
     if callback is None:
         callback = donothing

--- a/NuMPI/Optimization/LBFGS.py
+++ b/NuMPI/Optimization/LBFGS.py
@@ -405,7 +405,7 @@ def l_bfgs(
         if iteration > maxcor:
             YTY = np.roll(YTY, (-1, -1), axis=(0, 1))
             YTY[-1, :-1] = YTY[:-1, -1] = (YTgrad[:-1] - YTgrad_prev[1:]).flat
-            YTY[-1, -1] = grad2prev - grad2 + 2 * YTgrad[-1]
+            YTY[-1, -1] = grad2prev - grad2 + 2 * YTgrad[-1, -1]
         else:
             # YTYm = pnp.dot(Y.T, Y)
             YTY = np.array(

--- a/NuMPI/Optimization/LBFGS.py
+++ b/NuMPI/Optimization/LBFGS.py
@@ -23,9 +23,7 @@
 # SOFTWARE.
 #
 
-# skip undefined names
-# flake8: noqa F821
-
+import logging
 
 import numpy as np
 
@@ -33,6 +31,8 @@ from .. import MPI
 from ..Tools import Reduction
 from .LineSearch import scalar_search_wolfe2
 from .Result import OptimizeResult
+
+_log = logging.getLogger(__name__)
 
 
 def donothing(*args, **kwargs):
@@ -64,11 +64,14 @@ def steepest_descent_wolfe2(x0, f_gradf, pnp=None, maxiter=10, args=(), **kwargs
     # if (iter.eq. 0.and..not.boxed) then
     #    stp = min(one / dnorm, stpmx)
 
-    alpha, phi, phi0, derphi = scalar_search_wolfe2(_phi_phiprime,
-                                                    maxiter=maxiter,
-                                                    phi0=phi0, derphi0=derphi0,
-                                                    step=min(1., 1. / np.sqrt(
-                                                        -derphi0)), **kwargs)
+    alpha, phi, phi0, derphi = scalar_search_wolfe2(
+        _phi_phiprime,
+        maxiter=maxiter,
+        phi0=phi0,
+        derphi0=derphi0,
+        step=min(1.0, 1.0 / np.sqrt(-derphi0)),
+        **kwargs,
+    )
 
     assert derphi is not None, "Line Search in first steepest descent failed"
     x = x0 - grad0 * alpha
@@ -76,10 +79,25 @@ def steepest_descent_wolfe2(x0, f_gradf, pnp=None, maxiter=10, args=(), **kwargs
     return x, gradf, x0, grad0, phi, phi0, derphi
 
 
-def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2e-9, maxiter=15000, maxls=20,
-           linesearch_options=dict(c1=1e-3, c2=0.9), disp=None, pnp=Reduction(MPI.COMM_WORLD), store_iterates=None,
-           printdb=donothing, callback=None, **options):
-    """
+def l_bfgs(
+    fun,
+    x,
+    args=(),
+    jac=None,
+    x_old=None,
+    maxcor=10,
+    gtol=1e-5,
+    ftol=2.2e-9,
+    maxiter=15000,
+    maxls=20,
+    linesearch_options=dict(c1=1e-3, c2=0.9),
+    disp=None,
+    comm=MPI.COMM_WORLD,
+    store_iterates=None,
+    callback=None,
+    **options,
+):
+    r"""
     Limited-memory L-BFGS optimization with MPI parallelization.
 
     The optimization converges if |grad|_{\infty} <= gtol or <= ftol is satisfied.
@@ -93,13 +111,18 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
     args : tuple, optional
         Extra arguments passed to the objective function and its derivatives (Jacobian).
     jac : bool or callable, optional
-        Method for computing the gradient vector. If it is a callable, it should be a function that returns the gradient vector. If it is a Boolean and is True, then `fun` should return the gradient along with the objective function.
+        Method for computing the gradient vector. If it is a callable, it should be a
+        function that returns the gradient vector. If it is a Boolean and is True, then
+        `fun` should return the gradient along with the objective function.
     x_old : ndarray, optional
-        Initial guess for the previous value of x. If None, a steepest descent step will be performed.
+        Initial guess for the previous value of x. If None, a steepest descent step will
+        be performed.
     maxcor : int, optional
-        The maximum number of variable metric corrections used to define the limited memory matrix.
+        The maximum number of variable metric corrections used to define the limited
+        memory matrix.
     gtol : float, optional
-        The iteration will stop when max{|proj g_i | i = 1, ..., n} <= gtol where pg_i is the i-th component of the projected gradient.
+        The iteration will stop when max{|proj g_i | i = 1, ..., n} <= gtol where pg_i
+        is the i-th component of the projected gradient.
     ftol : float, optional
         The iteration will stop when (f^k - f^{k+1})/max{|f^k|,|f^{k+1}|,1} <= ftol.
     maxiter : int, optional
@@ -110,12 +133,10 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
         A dictionary with optional settings for the line search parameters.
     disp : int, optional
         If disp is a positive integer, convergence messages will be printed.
-    pnp : Reduction, optional
-        Parallelization object from the NuMPI package.
+    comm : MPI.Comm, optional
+        MPI communicator.
     store_iterates : bool, optional
         If True, the result at each iteration is stored in a list.
-    printdb : callable, optional
-        Debugging print function.
     callback : callable, optional
         Called after each iteration.
     options : dict, optional
@@ -124,17 +145,22 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
     Returns
     -------
     result : OptimizeResult
-        The optimization result represented as a OptimizeResult object. Important attributes are: x the solution array, success a Boolean flag indicating if the optimizer exited successfully and message which describes the cause of the termination.
+        The optimization result represented as a OptimizeResult object. Important
+        attributes are: x the solution array, success a Boolean flag indicating if the
+        optimizer exited successfully and message which describes the cause of the
+        termination.
     """
     # user can provide x in the shape of his convenience
     # but we will work with the shape (-1, 1)
     original_shape = x.shape
 
+    pnp = Reduction(comm)
+
     if callback is None:
         callback = donothing
 
-    # print("jac = {}, type = {}".format(jac, type(jac)))
     if jac is True:
+
         def fun_grad(x, *args):
             """
             This function evaluates the objective function and its gradient at the point x.
@@ -156,8 +182,7 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
             return f, grad.reshape((-1, 1))
 
     elif jac is False:
-        raise NotImplementedError(
-            "Numerical evaluation of gradient not implemented")
+        raise NotImplementedError("Numerical evaluation of gradient not implemented")
     else:
         # function and gradient provided sepatately
 
@@ -188,9 +213,9 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
 
     if x_old is None:
         x_old = x.copy()
-        x, grad, x_old, grad_old, phi, phi_old, derphi = \
-            steepest_descent_wolfe2(x_old, fun_grad, pnp=pnp, maxiter=maxls,
-                                    args=args, **linesearch_options)
+        x, grad, x_old, grad_old, phi, phi_old, derphi = steepest_descent_wolfe2(
+            x_old, fun_grad, pnp=pnp, maxiter=maxls, args=args, **linesearch_options
+        )
     else:
         # phi_old is never used, except for the convergence
         phi_old, grad_old = fun_grad(x_old, *args)
@@ -208,38 +233,45 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
     Ylist = []  # history of gradient differences
     R = np.zeros((0, 0))
 
-    grad2 = pnp.sum(grad ** 2)
+    grad2 = pnp.sum(grad**2)
 
     alpha = 0  # line search step size
 
     if disp:
-        if MPI.COMM_WORLD.rank == 0:
+        if comm.rank == 0:
             iteration_title = "iteration"
             phi_title = "f"
             phi_change_title = "Δf"
             max_grad_title = "max ∇ f"
-            norm_grad_title = "||∇ f||²"
+            norm_grad_title = "||∇ f||"
             print(
-                f"{iteration_title:<10} {phi_title:<10} {phi_change_title:<10} {max_grad_title:<10} {norm_grad_title:<10}")
-            print(f"---------- ---------- ---------- ---------- ----------")
+                f"{iteration_title:<10} {phi_title:<10} {phi_change_title:<10} "
+                f"{max_grad_title:<10} {norm_grad_title:<10}"
+            )
+            print("---------- ---------- ---------- ---------- ----------")
+
+    STgrad_prev = None
+    YTgrad_prev = None
+    p1 = None
+    p2 = None
+    D = None
+    YTY = None
 
     # Start loop
-    # printdb(k)
     while True:
         # Update Sk,Yk
-        # print("k= {}".format(k))
         if iteration > maxcor:
             # S = np.roll(S, -1)
             # S[:, -1] = (x - x_old).flat
 
             Slist[:-1] = Slist[1:]
-            Slist[-1] = (x - x_old)
+            Slist[-1] = x - x_old
 
             # Y = np.roll(Y, -1)
             # Y[:, -1] = (grad - grad_old).flat
 
             Ylist[:-1] = Ylist[1:]
-            Ylist[-1] = (grad - grad_old)
+            Ylist[-1] = grad - grad_old
 
         else:
             # S = np.hstack([S, x - x_old])
@@ -261,69 +293,67 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
         callback(x)
 
         max_grad = pnp.max(np.abs(grad))
-        norm_grad = grad2
+        norm_grad = np.sqrt(grad2)
         phi_change = phi_old - phi
 
         if disp:
-            if MPI.COMM_WORLD.rank == 0:
-                print(f"{iteration:<10} {phi:<10.7g} {phi_change:<10.7g} {max_grad:<10.7g} {norm_grad:<10.7g}")
+            if comm.rank == 0:
+                print(
+                    f"{iteration:<10} {phi:<10.7g} {phi_change:<10.7g} {max_grad:<10.7g} {norm_grad:<10.7g}"
+                )
 
-        if (max_grad < gtol):
-            print("CONVERGED because gradient tolerance was reached")
-            result = OptimizeResult({
-                'success': True,
-                'x': x.reshape(
-                    original_shape),
-                'fun': phi,
-                'jac': grad.reshape(
-                    original_shape),
-                'nit': iteration,
-                'message':
-                    'CONVERGENCE: '
-                    'NORM_OF_GRADIENT_<=_GTOL',
-                'iterates': iterates,
-                'max_grad': max_grad,
-                'norm_grad': norm_grad,
-                'phi_change': phi_change
-            })
+        if max_grad < gtol:
+            _log.info("CONVERGED because gradient tolerance was reached")
+            result = OptimizeResult(
+                {
+                    "success": True,
+                    "x": x.reshape(original_shape),
+                    "fun": phi,
+                    "jac": grad.reshape(original_shape),
+                    "nit": iteration,
+                    "message": "CONVERGENCE: " "NORM_OF_GRADIENT_<=_GTOL",
+                    "iterates": iterates,
+                    "max_grad": max_grad,
+                    "norm_grad": norm_grad,
+                    "phi_change": phi_change,
+                }
+            )
             return result
 
-        if (phi_change <= ftol * max((1, abs(phi), abs(phi_old)))):
-            print("CONVERGED because function tolerance was reached")
-            result = OptimizeResult({
-                'success': True,
-                'x': x.reshape(
-                    original_shape),
-                'fun': phi,
-                'jac': grad.reshape(
-                    original_shape),
-                'nit': iteration,
-                'message':
-                    'CONVERGENCE: '
-                    'REL_REDUCTION_OF_F_<=_FACTR*EPSMCH',
-                'iterates': iterates,
-                'max_grad': max_grad,
-                'norm_grad': norm_grad,
-                'phi_change': phi_change
-            })
+        if phi_change <= ftol * max((1, abs(phi), abs(phi_old))):
+            _log.info("CONVERGED because function tolerance was reached")
+            result = OptimizeResult(
+                {
+                    "success": True,
+                    "x": x.reshape(original_shape),
+                    "fun": phi,
+                    "jac": grad.reshape(original_shape),
+                    "nit": iteration,
+                    "message": "CONVERGENCE: " "REL_REDUCTION_OF_F_<=_FACTR*EPSMCH",
+                    "iterates": iterates,
+                    "max_grad": max_grad,
+                    "norm_grad": norm_grad,
+                    "phi_change": phi_change,
+                }
+            )
 
             return result
 
         if iteration > maxiter:
-            print("CONVERGED because maximum number of iterations reached")
-            result = OptimizeResult({
-                'success': False,
-                'x': x.reshape(
-                    original_shape),
-                'fun': phi,
-                'jac': grad.reshape(
-                    original_shape),
-                'nit': iteration,
-                'iterates': iterates,
-                'max_grad': max_grad,
-                'norm_grad': norm_grad,
-                'phi_change': phi_change
-            })
+            _log.info("CONVERGED because maximum number of iterations reached")
+            result = OptimizeResult(
+                {
+                    "success": False,
+                    "x": x.reshape(original_shape),
+                    "fun": phi,
+                    "jac": grad.reshape(original_shape),
+                    "nit": iteration,
+                    "iterates": iterates,
+                    "max_grad": max_grad,
+                    "norm_grad": norm_grad,
+                    "phi_change": phi_change,
+                }
+            )
 
             return result
         ###########
@@ -331,41 +361,44 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
 
         STgrad = np.array([pnp.dot(si.T, grad) for si in Slist]).reshape(-1, 1)
         YTgrad = np.array([pnp.dot(yi.T, grad) for yi in Ylist]).reshape(-1, 1)
-        # STgrad = pnp.dot(S.T, grad)
-        # YTgrad = pnp.dot(Y.T, grad)
 
         if iteration > maxcor:
             S_now_T_grad_prev = np.roll(STgrad_prev, -1)
-            S_now_T_grad_prev[-1] = - alpha * gamma * grad2prev - alpha * (
-                    STgrad_prev.T.dot(p1) + gamma * YTgrad_prev.T.dot(p2))
+            S_now_T_grad_prev[-1] = -alpha * gamma * grad2prev - alpha * (
+                STgrad_prev.T.dot(p1) + gamma * YTgrad_prev.T.dot(p2)
+            )
         else:  # straightforward Version
             S_now_T_grad_prev = np.array(
-                [pnp.dot(si.T, grad_old) for si in Slist]).reshape(-1, 1)
+                [pnp.dot(si.T, grad_old) for si in Slist]
+            ).reshape(-1, 1)
 
         if iteration > maxcor:
-            R = np.roll(R, (-1, -1),
-                        axis=(0, 1))  # mxm Matrix hold by all Processors
+            R = np.roll(R, (-1, -1), axis=(0, 1))  # mxm Matrix hold by all Processors
             R[-1, :] = 0
             STym1 = STgrad - S_now_T_grad_prev
             R[:, -1] = STym1.flat  # O(m x n)
 
         elif iteration == 1:
-            # Rm = np.triu(pnp.dot(S.T, Y))
-            R = np.triu(np.array(
-                [[pnp.dot(si.T, yi).item() for yi in Ylist] for si in Slist]))
-            # print(R)
+            R = np.triu(
+                np.array([[pnp.dot(si.T, yi).item() for yi in Ylist] for si in Slist])
+            )
         else:
             # Rm = np.vstack([Rm, np.zeros(k - 1)])
             # Rm = np.hstack([Rm, pnp.dot(S.T, Y[:, -1]).reshape(k, 1)])
             R = np.vstack([R, np.zeros(iteration - 1)])
-            R = np.hstack([R, np.array(
-                [pnp.dot(si.T, Ylist[-1]) for si in Slist]).reshape(iteration, 1)])
+            R = np.hstack(
+                [
+                    R,
+                    np.array([pnp.dot(si.T, Ylist[-1]) for si in Slist]).reshape(
+                        iteration, 1
+                    ),
+                ]
+            )
         if iteration > maxcor:
             D = np.roll(D, (-1, -1), axis=(0, 1))
             # D[-1,-1] = np.dot(Y[:,-1],Y[:,-1])# yk-1Tyk-1 # TOOPTIMIZE
             D[-1, -1] = R[-1, -1]
         else:
-            # D = np.diag(np.einsum("ik,ik -> k", S, Y))
             D = np.diag(R.diagonal())
         assert D[-1, -1] > 0, "k = {}: ".format(iteration)  # Assumption of Theorem 2.2
 
@@ -376,27 +409,22 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
         else:
             # YTYm = pnp.dot(Y.T, Y)
             YTY = np.array(
-                [[pnp.dot(yi1.T, yi2).item() for yi2 in Ylist] for yi1 in
-                 Ylist])
+                [[pnp.dot(yi1.T, yi2).item() for yi2 in Ylist] for yi1 in Ylist]
+            )
         # Step 5.
-        gamma = D[-1, -1] / YTY[
-            -1, -1]  # n.b. D[-1,-1] = sk-1T yk-1 = yk-1T sk-1
+        gamma = D[-1, -1] / YTY[-1, -1]  # n.b. D[-1,-1] = sk-1T yk-1 = yk-1T sk-1
 
         # Step 6. and 7. together
         Rinv = np.linalg.inv(R)
         RiSg = Rinv.dot(STgrad)
         p1 = Rinv.T.dot(D + gamma * YTY).dot(RiSg) - gamma * Rinv.T.dot(YTgrad)
-        p2 = - RiSg  # TODO
+        p2 = -RiSg  # TODO
 
-        # temphstack=np.hstack([S, gamma * Y])
-
-        # Hgradm = gamma * grad + S.dot(p1)  + gamma * Y.dot(p2)
         Hgrad = gamma * grad
         for si, yi, p1i, p2i in zip(Slist, Ylist, p1.flat, p2.flat):
             Hgrad += si * p1i.item() + gamma * yi * p2i.item()
 
         phi_old = float(phi)
-        # printdb("Linesearch: ")
         grad_old[:] = grad
         x_old[:] = x
 
@@ -412,28 +440,26 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
             phi0=phi,
             derphi0=pnp.dot(grad.T, -Hgrad).item(),
             maxiter=maxls,
-            **linesearch_options)
-
-        printdb("derphi: {}".format(derphi))
+            **linesearch_options,
+        )
 
         if derphi is None:
-            print("line-search did not converge")
-            result = OptimizeResult({
-                'success': False,
-                'x': x.reshape(
-                    original_shape),
-                'fun': phi,
-                'jac': grad.reshape(
-                    original_shape),
-                'nit': iteration,
-                'iterates': iterates,
-                'message':
-                    'CONVERGENCE: '
-                    'line-search did not converge',
-                'max_grad': max_grad,
-                'norm_grad': norm_grad,
-                'phi_change': phi_change
-            })
+            if comm.rank == 0:
+                _log.info("line-search did not converge")
+            result = OptimizeResult(
+                {
+                    "success": False,
+                    "x": x.reshape(original_shape),
+                    "fun": phi,
+                    "jac": grad.reshape(original_shape),
+                    "nit": iteration,
+                    "iterates": iterates,
+                    "message": "CONVERGENCE: " "line-search did not converge",
+                    "max_grad": max_grad,
+                    "norm_grad": norm_grad,
+                    "phi_change": phi_change,
+                }
+            )
             return result
 
         x = x - Hgrad * alpha
@@ -441,16 +467,16 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
         if store_iterates:
             iterate = OptimizeResult(
                 {
-                    'x': x.copy().reshape(original_shape),
-                    'fun': phi,
-                    'jac': grad.reshape(original_shape),
-                    'max_grad': max_grad,
-                    'norm_grad': norm_grad,
-                    'phi_change': phi_change
-                })
+                    "x": x.copy().reshape(original_shape),
+                    "fun": phi,
+                    "jac": grad.reshape(original_shape),
+                    "max_grad": max_grad,
+                    "norm_grad": norm_grad,
+                    "phi_change": phi_change,
+                }
+            )
             iterates.append(iterate)
 
-        printdb("k = {}".format(iteration))
         iteration = iteration + 1
 
         STgrad_prev = STgrad.copy()

--- a/NuMPI/Optimization/LBFGS.py
+++ b/NuMPI/Optimization/LBFGS.py
@@ -261,8 +261,10 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
         callback(x)
 
         max_grad = pnp.max(np.abs(grad))
-        abs_grad = np.linalg.norm(grad)  # TODO[Martin, Lars]: is this parallel ???
-        # abs_grad = np.sqrt(pnp.dot(grad.transpose(), grad))
+        abs_grad = np.linalg.norm(grad)  # TODO[Martin, Lars]: is this parallel ??? # What is this?
+        abs_grad = pnp.sum(np.asarray(grad) ** 2) # This is squred norm of gradient
+        # max_grad_title = "max ∇ f"
+        # abs_grad_title = "|∇ f|"
         phi_change = phi_old - phi
 
         if disp:
@@ -287,8 +289,6 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
                 'abs_grad': abs_grad,
                 'phi_change': phi_change
             })
-            # if iterates:
-            #    result['iterates'] = iterates
             return result
 
         if (phi_change <= ftol * max((1, abs(phi), abs(phi_old)))):
@@ -309,8 +309,7 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
                 'abs_grad': abs_grad,
                 'phi_change': phi_change
             })
-            # if iterates:
-            #    result['iterates'] = iterates
+
             return result
 
         if iteration > maxiter:

--- a/NuMPI/Optimization/LBFGS.py
+++ b/NuMPI/Optimization/LBFGS.py
@@ -218,9 +218,9 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
             phi_title = "f"
             phi_change_title = "Δf"
             max_grad_title = "max ∇ f"
-            abs_grad_title = "|∇ f|"
+            norm_grad_title = "||∇ f||²"
             print(
-                f"{iteration_title:<10} {phi_title:<10} {phi_change_title:<10} {max_grad_title:<10} {abs_grad_title:<10}")
+                f"{iteration_title:<10} {phi_title:<10} {phi_change_title:<10} {max_grad_title:<10} {norm_grad_title:<10}")
             print(f"---------- ---------- ---------- ---------- ----------")
 
     # Start loop
@@ -261,15 +261,12 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
         callback(x)
 
         max_grad = pnp.max(np.abs(grad))
-        abs_grad = np.linalg.norm(grad)  # TODO[Martin, Lars]: is this parallel ??? # What is this?
-        abs_grad = pnp.sum(np.asarray(grad) ** 2) # This is squred norm of gradient
-        # max_grad_title = "max ∇ f"
-        # abs_grad_title = "|∇ f|"
+        norm_grad = grad2
         phi_change = phi_old - phi
 
         if disp:
             if MPI.COMM_WORLD.rank == 0:
-                print(f"{iteration:<10} {phi:<10.7g} {phi_change:<10.7g} {max_grad:<10.7g} {abs_grad:<10.7g}")
+                print(f"{iteration:<10} {phi:<10.7g} {phi_change:<10.7g} {max_grad:<10.7g} {norm_grad:<10.7g}")
 
         if (max_grad < gtol):
             print("CONVERGED because gradient tolerance was reached")
@@ -286,7 +283,7 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
                     'NORM_OF_GRADIENT_<=_GTOL',
                 'iterates': iterates,
                 'max_grad': max_grad,
-                'abs_grad': abs_grad,
+                'norm_grad': norm_grad,
                 'phi_change': phi_change
             })
             return result
@@ -306,7 +303,7 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
                     'REL_REDUCTION_OF_F_<=_FACTR*EPSMCH',
                 'iterates': iterates,
                 'max_grad': max_grad,
-                'abs_grad': abs_grad,
+                'norm_grad': norm_grad,
                 'phi_change': phi_change
             })
 
@@ -324,7 +321,7 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
                 'nit': iteration,
                 'iterates': iterates,
                 'max_grad': max_grad,
-                'abs_grad': abs_grad,
+                'norm_grad': norm_grad,
                 'phi_change': phi_change
             })
 
@@ -434,7 +431,7 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
                     'CONVERGENCE: '
                     'line-search did not converge',
                 'max_grad': max_grad,
-                'abs_grad': abs_grad,
+                'norm_grad': norm_grad,
                 'phi_change': phi_change
             })
             return result
@@ -448,7 +445,7 @@ def l_bfgs(fun, x, args=(), jac=None, x_old=None, maxcor=10, gtol=1e-5, ftol=2.2
                     'fun': phi,
                     'jac': grad.reshape(original_shape),
                     'max_grad': max_grad,
-                    'abs_grad': abs_grad,
+                    'norm_grad': norm_grad,
                     'phi_change': phi_change
                 })
             iterates.append(iterate)

--- a/NuMPI/Testing/Assertions.py
+++ b/NuMPI/Testing/Assertions.py
@@ -3,6 +3,13 @@ import numpy as np
 from NuMPI import MPI
 
 
+def parallel_assert(comm, condition, message="Assertion failed"):
+    failed_recv = np.ones(1, dtype=int)
+    comm.Allreduce(np.array([not condition], dtype=int), failed_recv, op=MPI.SUM)
+    if failed_recv[0] > 0:
+        raise AssertionError(message)
+
+
 def _assert_one(fun):
     def assert_func(comm, rank, *args, **kwargs):
         exception = None

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Development Installation
 
 Clone the repository.
 
-To use the code, use the env.sh script to set the environment:
+To use the code, install the current package as editable:
 
 ```
-source /path/to/NuMPI/env.sh
+pip install -e .[test]
 ```
 
 Testing

--- a/helpers/profile_Rosenbrock.py
+++ b/helpers/profile_Rosenbrock.py
@@ -22,15 +22,15 @@
 # SOFTWARE.
 #
 
-import numpy as np
-from NuMPI.Tools.Reduction import Reduction
-from test.Optimization.MPIMinimizationProblems import MPI_Quadratic
+import cProfile
 import time
+from test.Optimization.MPIMinimizationProblems import MPI_Quadratic
 
-from NuMPI.Optimization.LBFGS import l_bfgs
+import numpy as np
 
 from NuMPI import MPI
-import cProfile
+from NuMPI.Optimization.LBFGS import l_bfgs
+from NuMPI.Tools.Reduction import Reduction
 
 
 def profile(filename=None, comm=MPI.COMM_WORLD):
@@ -79,7 +79,7 @@ x0 = PObjective.startpoint()
 
 LBFGS = profile("profile_out", comm)(l_bfgs)
 res, t = timer(LBFGS, PObjective.f, x0, jac=PObjective.grad, maxcor=maxcor,
-               maxiter=100000, gtol=(1e-5), pnp=pnp)
+               maxiter=100000, gtol=(1e-5), comm=comm)
 assert res.success
 if MPI.COMM_WORLD.Get_rank() == 0:
     print("elapsed time: {}".format(t))

--- a/test/IO/fixtures.py
+++ b/test/IO/fixtures.py
@@ -74,6 +74,8 @@ def globaldata3d(request, comm):
     params=[
         ("C", (13, 7)),
         ("F", (13, 7)),
+        ("C", (7, 13)),
+        ("F", (7, 13)),
         ("C", (13, 11, 27)),
         ("F", (13, 11, 27)),
         ("C", (15, 7, 9, 3)),
@@ -86,9 +88,11 @@ def datagrid(request, comm):
     np.random.seed(2)
     if order == "C":
         data = np.random.random(nb_domain_grid_pts)
+        # data = np.arange(np.prod(nb_domain_grid_pts)).reshape(nb_domain_grid_pts)
         assert data.flags.c_contiguous
     elif order == "F":
         data = np.random.random(nb_domain_grid_pts[::-1]).transpose()
+        # data = np.arange(np.prod(nb_domain_grid_pts)).reshape(nb_domain_grid_pts[::-1]).T
         assert data.flags.f_contiguous
 
     return data

--- a/test/IO/fixtures.py
+++ b/test/IO/fixtures.py
@@ -72,6 +72,8 @@ def globaldata3d(request, comm):
 
 @pytest.fixture(
     params=[
+        ("C", (2, 3)),
+        ("F", (2, 3)),
         ("C", (13, 7)),
         ("F", (13, 7)),
         ("C", (7, 13)),

--- a/test/IO/test_io.py
+++ b/test/IO/test_io.py
@@ -258,6 +258,8 @@ def test_parallel_save(comm, datagrid):
         comm=comm,
     )
 
+    comm.barrier()
+
     loaded_data = np.load("test.npy")
 
     assert_one_array_equal(comm, 0, loaded_data, datagrid)

--- a/test/IO/test_io.py
+++ b/test/IO/test_io.py
@@ -23,8 +23,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-
-
+import functools
 import os
 import warnings
 from test.IO.utils import make_2d_slab_x, make_2d_slab_y, subdivide
@@ -39,6 +38,7 @@ from NuMPI.IO.NPY import (MPIFileTypeError, NPYFile, load_npy, mpi_open,
 from NuMPI.Testing.Assertions import (assert_all_allclose,
                                       assert_all_array_equal,
                                       assert_one_array_equal)
+from NuMPI.Tools import Reduction
 
 testdir = os.path.dirname(os.path.realpath(__file__))
 
@@ -248,10 +248,16 @@ def test_make_mpi_file_view(comm_self, npyfile, mode):
 
 
 def test_parallel_save(comm, datagrid):
+    order = "F" if Reduction(comm).any(datagrid.flags.f_contiguous) else "C"
+    fn = (
+        f"test_{comm.size}_{order}_"
+        f"{functools.reduce(lambda x, y: f'{x}x{y}', datagrid.shape)}.npy"
+    )
+
     distdata = subdivide(comm, datagrid)
 
     save_npy(
-        "test.npy",
+        fn,
         distdata.data,
         subdomain_locations=distdata.subdomain_locations,
         nb_grid_pts=distdata.nb_domain_grid_pts,
@@ -259,14 +265,16 @@ def test_parallel_save(comm, datagrid):
     )
 
     comm.barrier()
+    # if comm.rank == 0:
+    #     np.save("ref_" + fn, datagrid)
 
-    loaded_data = np.load("test.npy")
+    loaded_data = np.load(fn)
 
     assert_one_array_equal(comm, 0, loaded_data, datagrid)
 
     comm.barrier()
     if comm.rank == 0:
-        os.remove("test.npy")
+        os.remove(fn)
 
 
 def test_parallel_load(comm, datagrid):

--- a/test/Optimization/show_parallel_speedup.py
+++ b/test/Optimization/show_parallel_speedup.py
@@ -23,13 +23,14 @@
 # SOFTWARE.
 #
 
+import time
+from test.Optimization.MPIMinimizationProblems import MPI_Quadratic
+
 import numpy as np
 from mpi4py import MPI
-from NuMPI.Tools import Reduction
-from test.Optimization.MPIMinimizationProblems import MPI_Quadratic
-import time
 
 from NuMPI.Optimization import l_bfgs
+from NuMPI.Tools import Reduction
 
 
 def timer(fun, *args, **kwargs):
@@ -95,7 +96,7 @@ def show_parallel_speedup():
 
             res[i], t[i] = timer(l_bfgs, PObjective.f, x0, jac=PObjective.grad,
                                  maxcor=maxcor, maxiter=100000, gtol=(1e-5),
-                                 store_iterates=None, pnp=pnp)
+                                 store_iterates=None, comm=comm)
             msg += "size {}:\n".format(size)
 
             assert res[i].success, "Minimization faild"

--- a/test/Optimization/test_cg.py
+++ b/test/Optimization/test_cg.py
@@ -1,5 +1,7 @@
-import pytest
 import numpy as np
+import pytest
+
+from NuMPI.Testing.Assertions import assert_all_allclose, parallel_assert
 
 try:
     import scipy.optimize
@@ -8,10 +10,11 @@ try:
 except ModuleNotFoundError:
     _scipy_present = False
 
-from NuMPI.Tools import Reduction
-from NuMPI.Optimization.CCGWithoutRestart import constrained_conjugate_gradients
-
 from test.Optimization.MPIMinimizationProblems import MPI_Quadratic
+
+from NuMPI.Optimization.CCGWithoutRestart import \
+    constrained_conjugate_gradients
+from NuMPI.Tools import Reduction
 
 
 def test_bugnicourt_cg(comm):
@@ -28,7 +31,7 @@ def test_bugnicourt_cg(comm):
         x0=xstart,
         communicator=comm
     )
-    assert res.success, res.message
+    parallel_assert(comm, res.success, res.message)
     print(res.nit)
 
 
@@ -50,9 +53,9 @@ def test_bugnicourt_cg_arbitrary_bounds(comm):
         bounds=bounds,
         gtol=1e-8
     )
-    assert res.success, res.message
+    parallel_assert(comm, res.success, res.message)
 
-    assert (res.x >= bounds).all()
+    parallel_assert(comm, (res.x >= bounds).all())
     print(res.nit)
 
     # TODO: we are not checking yet that the result is the same in parallel.
@@ -67,9 +70,9 @@ def test_bugnicourt_cg_arbitrary_bounds(comm):
             method="L-BFGS-B",
             jac=True,
             options=dict(gtol=1e-8, ftol=0))
-        assert res_ref.success, res_ref.message
+        parallel_assert(comm, res_ref.success, res_ref.message)
 
-        np.testing.assert_allclose(res.x, res_ref.x, atol=1e-6)
+        assert_all_allclose(comm, res.x, res_ref.x, atol=1e-6)
 
 
 def test_bugnicourt_cg_active_bounds(comm):
@@ -86,7 +89,7 @@ def test_bugnicourt_cg_active_bounds(comm):
         x0=xstart,
         communicator=comm
     )
-    assert res.success, res.message
+    parallel_assert(comm, res.success, res.message)
     print(res.nit)
     print(np.count_nonzero(res.x == 0))
 
@@ -106,7 +109,7 @@ def test_bugnicourt_cg_mean_val(comm):
         mean_val=1.,
         communicator=comm
     )
-    assert res.success, res.message
+    parallel_assert(comm, res.success, res.message)
     print(res.nit)
 
 
@@ -125,5 +128,5 @@ def test_bugnicourt_cg_mean_val_active_bounds(comm):
         mean_val=1.,
         communicator=comm
     )
-    assert res.success, res.message
+    parallel_assert(comm, res.success, res.message)
     print(res.nit)


### PR DESCRIPTION
new:

1.  when the line search fails, we get the last  results
2. When the store_iterates  option was set to TRUE, it did not work because:  
 OLD:  if store_iterates == 'iterate':  
 NEW: if store_iterates: 
3. add norms to the results list  (NO new norms, I just add them to results)

Question: 

abs_grad = np.linalg.norm(grad)  # TODO[Martin, Lars]: is this parallel ???

