### PR TITLE
ENH: Bound-constrained trust-region Newton-CG (tr_newton_bounded)

### DIFF
--- a/NuMPI/Optimization/BoundedTRNewtonCG.py
+++ b/NuMPI/Optimization/BoundedTRNewtonCG.py
@@ -433,11 +433,20 @@ def tr_newton_bounded(
         # Inexact-evaluation control: the evaluation error must stay below a
         # fraction of the predicted reduction, or the acceptance ratio is
         # noise (Conn-Gould-Toint 8.4; Kouri et al. 2013/14). The caller
-        # tightens its inner solves and both points are re-evaluated.
+        # tightens its inner solves and both points are re-evaluated. If a
+        # retry fails to reduce the reported error, the caller has hit its
+        # accuracy floor (e.g. the attainable residual of a single-precision
+        # solve) -- stop retrying and let the rho-test decide with the best
+        # available accuracy.
         if fun_error is not None and request_accuracy is not None:
+            prev_err = None
             for _ in range(max_accuracy_retries):
-                if fun_error() <= eta_f * pred:
+                err = fun_error()
+                if err <= eta_f * pred:
                     break
+                if prev_err is not None and err > 0.9 * prev_err:
+                    break  # no further improvement possible
+                prev_err = err
                 request_accuracy(eta_f * pred)
                 phi, grad = fun_grad(x)
                 phi_try, grad_try = fun_grad(x_try)

--- a/NuMPI/Optimization/BoundedTRNewtonCG.py
+++ b/NuMPI/Optimization/BoundedTRNewtonCG.py
@@ -1,0 +1,499 @@
+#
+# Copyright 2026 Lars Pastewka
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""
+Bound-constrained trust-region Newton-CG with optional index pinning and
+optional inexact-evaluation (noise) control.
+
+Feasible set (same as :func:`~NuMPI.Optimization.BoundedLBFGS.l_bfgs_bounded`):
+
+    F = { x : lo <= x <= hi, x[zero_mask] = 0 }
+
+Each iteration:
+
+1. Build the box-active-masked gradient ``r_free`` (components where ``x``
+   sits on an active bound *and* the gradient points further into the bound
+   are zeroed; pinned indices are always zeroed). Its infinity norm is the
+   convergence measure -- identical to ``l_bfgs_bounded``, so runs are
+   directly comparable.
+2. Approximately minimize the quadratic model
+   ``m(s) = r_freeᵀ s + ½ sᵀ B s`` over the trust region ``||s|| <= Delta``,
+   restricted to the free subspace, with the Steihaug-Toint truncated CG
+   (Nocedal & Wright, Algorithm 7.2). The model Hessian ``B`` is supplied
+   matrix-free via ``hessp`` and only needs to be *bounded* -- inexact
+   Hessian-vector products (e.g. from truncated inner solves of an outer
+   PDE-constrained problem) do not break global convergence; negative
+   curvature is exploited by stepping to the trust-region boundary.
+3. Accept or reject the projected trial point ``x_try = Pi_F(x + s)`` by the
+   reduction ratio ``rho = (f - f_try) / pred`` and update the radius
+   (reject below ``eta``; shrink x1/4 below rho=0.25; grow x2, capped, above
+   rho=0.75 when the step reached the boundary). A boundary-limited step is
+   never counted as converged.
+
+**Robustness to inexact (noisy) objectives.** Unlike a backtracking line
+search -- whose sufficient-decrease test must resolve decreases that shrink
+``∝ alpha`` towards zero and hence *always* drowns in evaluation noise
+eventually -- the trust-region test compares the actual reduction against the
+*computable* predicted reduction ``pred``. When the caller can bound its own
+evaluation error (e.g. via an adjoint-weighted residual of a truncated inner
+solve), pass ``fun_error``/``request_accuracy``: the driver then enforces the
+standard inexact-trust-region condition ``|f_err| <= eta_f * pred``
+(Conn, Gould & Toint 2000, ch. 8.4/10.6; Kouri et al., SISC 2013/14),
+requesting tighter inner accuracy exactly when the noise would corrupt the
+acceptance test. With both hooks ``None`` this is a classic exact
+trust-region method.
+
+MPI-parallel: ``x``/gradient/bounds/``hessp`` operate on *local* per-rank
+slices; the scalar objective must be globally reduced; all reductions go
+through the caller-supplied ``pnp``.
+"""
+
+import logging
+
+import numpy as np
+
+from ..Tools import Reduction
+from ._lbfgs_helpers import _kkt_residual
+from .Result import OptimizeResult
+
+_log = logging.getLogger(__name__)
+
+
+def _free_mask(grad, x, lo, hi, zero_mask, tol_box=1e-12):
+    """Boolean mask of the *free* variables: not pinned, and not sitting on an
+    active box face with the gradient pointing further into it (the complement
+    of the components :func:`_kkt_residual` zeroes)."""
+    free = np.ones(x.shape, dtype=bool)
+    if zero_mask is not None:
+        free &= ~zero_mask
+    if lo is not None:
+        free &= ~((x <= lo + tol_box) & (grad >= 0.0))
+    if hi is not None:
+        free &= ~((x >= hi - tol_box) & (grad <= 0.0))
+    return free
+
+
+def _to_boundary(s, d, sds, dds, sdd, delta):
+    """Both roots ``tau`` of ``||s + tau d||^2 = delta^2``.
+
+    ``sds = sᵀs``, ``dds = dᵀd``, ``sdd = sᵀd`` are the (already reduced)
+    dot products. Returns ``(tau_minus, tau_plus)`` with
+    ``tau_minus <= tau_plus``."""
+    tmp = np.sqrt(max(sdd * sdd - dds * (sds - delta * delta), 0.0))
+    return (-sdd - tmp) / dds, (-sdd + tmp) / dds
+
+
+def _steihaug_cg(hessp_free, g_free, delta, tol, maxiter, pnp):
+    """Steihaug-Toint truncated CG on ``min m(s) = gᵀs + ½ sᵀBs`` s.t.
+    ``||s|| <= delta`` (Nocedal & Wright, Algorithm 7.2).
+
+    ``hessp_free`` must map a free-subspace vector to ``B v`` masked to the
+    free subspace. Returns ``(s, pred, on_boundary, status, nb_hessp)`` with
+    ``pred = m(0) - m(s) = -m(s) >= 0`` the predicted reduction.
+
+    Three exits: residual tolerance (interior step), negative curvature or
+    trust-region crossing (both: step to the boundary). For negative
+    curvature both sphere intersections are evaluated and the one with the
+    smaller model value is taken (the muSpectre convention); for a
+    trust-region crossing during a positive-curvature step the positive root
+    is the minimizer along ``d``.
+    """
+    s = np.zeros_like(g_free)
+    Bs = np.zeros_like(g_free)  # running B s, for cheap model evaluations
+    r = g_free.copy()  # residual of grad m = g + B s at s = 0
+    d = -r
+    rr = pnp.sum(r * r)
+    g_norm = np.sqrt(rr)
+    if g_norm == 0.0:
+        return s, 0.0, False, "zero gradient", 0
+    rtol2 = (tol * g_norm) ** 2
+
+    def model(sv, Bsv):
+        # m(s) = gᵀ s + ½ sᵀ B s, all-reduced.
+        return pnp.sum(g_free * sv) + 0.5 * pnp.sum(sv * Bsv)
+
+    nb_hessp = 0
+    for _ in range(maxiter):
+        Bd = hessp_free(d)
+        nb_hessp += 1
+        dBd = pnp.sum(d * Bd)
+        sds = pnp.sum(s * s)
+        sdd = pnp.sum(s * d)
+        dds = pnp.sum(d * d)
+        if dBd <= 0.0:
+            # Negative curvature: the model is unbounded along d; go to the
+            # sphere. Evaluate both intersections, keep the smaller model.
+            tau_m, tau_p = _to_boundary(s, d, sds, dds, sdd, delta)
+            cand = []
+            for tau in (tau_m, tau_p):
+                sv = s + tau * d
+                Bsv = Bs + tau * Bd
+                cand.append((model(sv, Bsv), sv, Bsv))
+            m_val, s, Bs = min(cand, key=lambda c: c[0])
+            return s, -m_val, True, "negative curvature", nb_hessp
+        alpha = rr / dBd
+        # Would the CG step leave the trust region?
+        step_norm2 = sds + 2.0 * alpha * sdd + alpha * alpha * dds
+        if step_norm2 >= delta * delta:
+            _, tau = _to_boundary(s, d, sds, dds, sdd, delta)
+            s = s + tau * d
+            Bs = Bs + tau * Bd
+            return s, -model(s, Bs), True, "boundary", nb_hessp
+        s = s + alpha * d
+        Bs = Bs + alpha * Bd
+        r = r + alpha * Bd
+        new_rr = pnp.sum(r * r)
+        if new_rr <= rtol2:
+            return s, -model(s, Bs), False, "tolerance", nb_hessp
+        d = -r + (new_rr / rr) * d
+        rr = new_rr
+    return s, -model(s, Bs), False, "maxiter", nb_hessp
+
+
+def tr_newton_bounded(
+    fun,
+    x0,
+    hessp,
+    args=(),
+    jac=None,
+    bounds_lo=None,
+    bounds_hi=None,
+    zero_mask=None,
+    gtol=1e-5,
+    maxiter=200,
+    delta0=0.05,
+    delta_max=0.5,
+    eta=0.1,
+    inner_tol=None,
+    inner_maxiter=None,
+    fun_error=None,
+    request_accuracy=None,
+    eta_f=0.25,
+    max_accuracy_retries=5,
+    comm=None,
+    pnp=None,
+    callback=None,
+    disp=False,
+):
+    """
+    Bound-constrained trust-region Newton-CG with optional index pinning and
+    optional inexact-evaluation control.
+
+    Parameters
+    ----------
+    fun : callable
+        Objective. If ``jac`` is ``True`` (or ``None``), ``fun(x, *args)``
+        must return ``(energy, gradient)``. If ``jac`` is a callable,
+        ``fun`` returns only the energy and ``jac(x, *args)`` returns the
+        gradient.
+    x0 : ndarray
+        Initial guess (any shape; local per-rank slice). Projected onto the
+        feasible set before the loop starts.
+    hessp : callable
+        Matrix-free model Hessian: ``hessp(x, v, *args)`` returns ``B v`` for
+        a direction ``v`` shaped like ``x`` (local slices in and out). ``B``
+        only needs to be symmetric and bounded -- an approximate or inexactly
+        evaluated Hessian slows local convergence but does not break global
+        convergence.
+    args : tuple, optional
+        Extra positional arguments forwarded to ``fun`` / ``jac`` / ``hessp``.
+    jac : bool or callable, optional
+        See ``fun``. Default ``None`` means ``jac=True`` (fused).
+    bounds_lo, bounds_hi : array_like or scalar, optional
+        Box bounds. ``None`` means unbounded on that side.
+    zero_mask : array_like of bool, optional
+        Indices pinned to ``x = 0`` (e.g. contact nodes).
+    gtol : float, optional
+        Convergence tolerance on the infinity norm of the box-masked
+        gradient (same measure as ``l_bfgs_bounded``). Default 1e-5.
+    maxiter : int, optional
+        Maximum number of outer iterations. Default 200.
+    delta0, delta_max : float, optional
+        Initial and maximum trust-region radius in **RMS-per-component
+        units**: the Euclidean radius is ``delta * sqrt(N_global)``, so the
+        same value expresses "typical change per variable" at any problem
+        size. Defaults 0.05 and 0.5.
+    eta : float, optional
+        Step acceptance threshold: accept iff ``rho >= eta``. Default 0.1.
+    inner_tol : float, optional
+        Relative residual tolerance of the Steihaug CG. ``None`` (default)
+        uses the superlinear forcing sequence
+        ``min(0.5, sqrt(||g_free||))`` (Nocedal & Wright, p. 169).
+    inner_maxiter : int, optional
+        Iteration cap of the Steihaug CG. Default: number of global degrees
+        of freedom (i.e. effectively uncapped).
+    fun_error : callable, optional
+        ``fun_error()`` returns a computable bound on the absolute error of
+        the most recent ``fun`` evaluation (e.g. an adjoint-weighted residual
+        of a truncated inner solve). Enables the inexact-trust-region
+        accuracy control.
+    request_accuracy : callable, optional
+        ``request_accuracy(target)`` asks the caller to tighten its inner
+        solves until the ``fun`` evaluation error is below the absolute
+        value ``target``. Called when ``fun_error() > eta_f * pred``; the
+        current and trial points are then re-evaluated.
+    eta_f : float, optional
+        Fraction of the predicted reduction the evaluation error must stay
+        below (``|f_err| <= eta_f * pred``). Default 0.25.
+    max_accuracy_retries : int, optional
+        Maximum tighten-and-re-evaluate rounds per iteration. Default 5.
+    comm, pnp : MPI.Comm or Reduction, optional
+        MPI communicator or pre-built reduction wrapper. Pass one, not both.
+    callback : callable, optional
+        ``callback(x)`` called after each *accepted* iterate.
+    disp : bool, optional
+        Print a per-iteration diagnostic table.
+
+    Returns
+    -------
+    OptimizeResult
+        With ``x, fun, jac, nit, success, message, max_grad`` plus the
+        trust-region diagnostics ``nb_hessp`` (total Hessian products),
+        ``delta_history``, ``rho_history`` (per outer iteration; ``rho`` is
+        ``nan`` where the model predicted no reduction).
+
+    Notes
+    -----
+    **MPI contract.** As for ``l_bfgs_bounded``: ``x``, the gradient, the
+    bounds, ``zero_mask`` and the vectors seen by ``hessp`` are all *local*
+    per-rank slices of the global problem; the scalar energy returned by
+    ``fun`` (and the error bound returned by ``fun_error``) must be
+    **globally reduced** (identical on every rank).
+    """
+    if comm is not None:
+        if pnp is not None:
+            raise RuntimeError("Please specify either `comm` or `pnp`, not both.")
+        pnp = Reduction(comm)
+    elif pnp is None:
+        pnp = np
+
+    original_shape = np.asarray(x0).shape
+
+    def _flat(a):
+        return a if (a is None or np.isscalar(a)) else np.asarray(a).ravel()
+
+    bounds_lo = _flat(bounds_lo)
+    bounds_hi = _flat(bounds_hi)
+    zero_mask = (
+        None if zero_mask is None else np.asarray(zero_mask).ravel().astype(bool)
+    )
+
+    if jac is True or jac is None:
+
+        def fun_grad(x):
+            phi, g = fun(x.reshape(original_shape), *args)
+            return phi, np.asarray(g).ravel()
+
+    elif jac is False:
+        raise NotImplementedError("Numerical evaluation of gradient not implemented")
+    else:
+
+        def fun_grad(x):
+            xr = x.reshape(original_shape)
+            return fun(xr, *args), np.asarray(jac(xr, *args)).ravel()
+
+    def hessp_flat(x, v):
+        return np.asarray(
+            hessp(x.reshape(original_shape), v.reshape(original_shape), *args)
+        ).ravel()
+
+    def project(y):
+        if bounds_lo is None and bounds_hi is None:
+            z = np.asarray(y, dtype=float)
+        else:
+            z = np.clip(y, bounds_lo, bounds_hi)
+        if zero_mask is not None:
+            z = np.where(zero_mask, 0.0, z)
+        return z
+
+    x = project(np.asarray(x0, dtype=float).ravel())
+
+    # Global degree-of-freedom count: converts the RMS radius parameters to
+    # Euclidean radii and caps the inner CG.
+    n_global = int(pnp.sum(np.full(1, float(x.size))))
+    delta = float(delta0) * np.sqrt(n_global)
+    delta_cap = float(delta_max) * np.sqrt(n_global)
+    if inner_maxiter is None:
+        inner_maxiter = n_global
+
+    phi, grad = fun_grad(x)
+
+    nb_hessp_total = 0
+    delta_history = []
+    rho_history = []
+    last_on_boundary = False
+
+    def _finish(success, nit, r_norm, message):
+        return OptimizeResult(
+            {
+                "success": bool(success),
+                "x": np.asarray(x).reshape(original_shape),
+                "fun": phi,
+                "jac": np.asarray(grad).reshape(original_shape),
+                "nit": int(nit),
+                "message": message,
+                "max_grad": float(r_norm),
+                "nb_hessp": int(nb_hessp_total),
+                "delta_history": delta_history,
+                "rho_history": rho_history,
+            }
+        )
+
+    if disp and (comm is None or pnp is np or comm.rank == 0):
+        print(
+            f"{'iter':<5} {'f':<14} {'|r|inf_free':<14} {'Delta_rms':<10} "
+            f"{'rho':<10} {'m_cg':<5} {'step':<6}"
+        )
+        print("-" * 68)
+
+    for iteration in range(1, maxiter + 1):
+        r_free = _kkt_residual(
+            grad, x, lo=bounds_lo, hi=bounds_hi, zero_mask=zero_mask
+        )
+        r_norm = pnp.max(np.abs(r_free))
+        # A boundary-limited step is never counted as converged (the model
+        # wanted to go further); test only after interior/accepted steps.
+        if r_norm < gtol and not last_on_boundary:
+            return _finish(
+                True, iteration - 1, r_norm,
+                "CONVERGENCE: NORM_OF_PROJECTED_GRADIENT_<=_GTOL",
+            )
+
+        free = _free_mask(grad, x, bounds_lo, bounds_hi, zero_mask)
+
+        def hessp_free(v):
+            return np.where(free, hessp_flat(x, np.where(free, v, 0.0)), 0.0)
+
+        tol_k = (
+            min(0.5, np.sqrt(r_norm)) if inner_tol is None else inner_tol
+        )
+        s, pred, on_boundary, status, nb_hessp = _steihaug_cg(
+            hessp_free, r_free, delta, tol_k, inner_maxiter, pnp
+        )
+        nb_hessp_total += nb_hessp
+
+        if pred <= 0.0:
+            # The model predicts no reduction (numerically degenerate
+            # subproblem). Shrink and retry; if the region collapses, stop.
+            delta *= 0.25
+            delta_history.append(delta / np.sqrt(n_global))
+            rho_history.append(np.nan)
+            last_on_boundary = False
+            if delta < 1e-14 * delta_cap:
+                return _finish(
+                    False, iteration, r_norm,
+                    "NO CONVERGENCE: trust region collapsed",
+                )
+            continue
+
+        x_try = project(x + s)
+        # Projection may clip the step at the box; the model reduction must
+        # be measured for the step actually taken.
+        s_eff = x_try - x
+        if pnp.max(np.abs(s_eff - s)) > 0.0:
+            Bs = hessp_free(s_eff)
+            nb_hessp_total += 1
+            pred = -(
+                pnp.sum(r_free * s_eff) + 0.5 * pnp.sum(s_eff * Bs)
+            )
+            if pred <= 0.0:
+                delta *= 0.25
+                delta_history.append(delta / np.sqrt(n_global))
+                rho_history.append(np.nan)
+                last_on_boundary = False
+                if delta < 1e-14 * delta_cap:
+                    return _finish(
+                        False, iteration, r_norm,
+                        "NO CONVERGENCE: trust region collapsed",
+                    )
+                continue
+
+        phi_try, grad_try = fun_grad(x_try)
+
+        # Inexact-evaluation control: the evaluation error must stay below a
+        # fraction of the predicted reduction, or the acceptance ratio is
+        # noise (Conn-Gould-Toint 8.4; Kouri et al. 2013/14). The caller
+        # tightens its inner solves and both points are re-evaluated.
+        if fun_error is not None and request_accuracy is not None:
+            for _ in range(max_accuracy_retries):
+                if fun_error() <= eta_f * pred:
+                    break
+                request_accuracy(eta_f * pred)
+                phi, grad = fun_grad(x)
+                phi_try, grad_try = fun_grad(x_try)
+
+        ared = phi - phi_try
+        # Round-off safeguard (Conn-Gould-Toint 17.4.2): near convergence the
+        # model reduction drops below the round-off floor of f itself; the
+        # ratio is then unresolvable noise and would reject good steps until
+        # the region collapses. If pred is below that floor and the actual
+        # value did not measurably increase, trust the model (rho = 1) -- the
+        # gradient test still guards convergence.
+        eps_f = 10.0 * np.finfo(float).eps * (1.0 + abs(phi))
+        if pred <= eps_f and ared >= -eps_f:
+            rho = 1.0
+        else:
+            rho = ared / pred
+
+        # Radius update (muSpectre blueprint): shrink hard on a bad model,
+        # grow only when the model is good AND the boundary was limiting.
+        if rho < 0.25:
+            delta *= 0.25
+        elif rho > 0.75 and on_boundary:
+            delta = min(2.0 * delta, delta_cap)
+        delta_history.append(delta / np.sqrt(n_global))
+        rho_history.append(float(rho))
+
+        accepted = rho >= eta
+        if disp and (comm is None or pnp is np or comm.rank == 0):
+            print(
+                f"{iteration:<5d} {phi:<14.6e} {r_norm:<14.4e} "
+                f"{delta / np.sqrt(n_global):<10.3e} {rho:<10.3g} "
+                f"{nb_hessp:<5d} {'acc' if accepted else 'rej':<6}"
+            )
+
+        if accepted:
+            x, phi, grad = x_try, phi_try, grad_try
+            last_on_boundary = on_boundary
+            if callback is not None:
+                callback(x.reshape(original_shape))
+        else:
+            last_on_boundary = False
+            if delta < 1e-14 * delta_cap:
+                return _finish(
+                    False, iteration, r_norm,
+                    "NO CONVERGENCE: trust region collapsed",
+                )
+
+    r_free = _kkt_residual(
+        grad, x, lo=bounds_lo, hi=bounds_hi, zero_mask=zero_mask
+    )
+    r_norm = pnp.max(np.abs(r_free))
+    if r_norm < gtol:
+        return _finish(
+            True, maxiter, r_norm,
+            "CONVERGENCE: NORM_OF_PROJECTED_GRADIENT_<=_GTOL",
+        )
+    return _finish(
+        False, maxiter, r_norm, "NO CONVERGENCE: MAXITERATIONS REACHED"
+    )

--- a/NuMPI/Optimization/__init__.py
+++ b/NuMPI/Optimization/__init__.py
@@ -36,6 +36,15 @@ Public entry points
                           optional box bounds (uses Armijo backtracking with
                           projection arc). Handles the same feasible set as
                           ``constrained_conjugate_gradients``.
+- ``tr_newton_bounded`` : bound-constrained trust-region Newton-CG
+                          (Steihaug-Toint truncated CG on the free subspace,
+                          matrix-free ``hessp``). Same feasible set and
+                          convergence measure as ``l_bfgs_bounded``. Optional
+                          ``fun_error``/``request_accuracy`` hooks enforce the
+                          inexact-trust-region condition
+                          ``|f_err| <= eta_f * pred`` for objectives evaluated
+                          by truncated inner solves -- robust where a
+                          noise-drowned line search stalls.
 - ``constrained_conjugate_gradients`` : bound-constrained CG (Bugnicourt
                           et al. 2018), optionally with a linear equality
                           via the ``linear_constraint`` kwarg or the legacy
@@ -77,6 +86,7 @@ treatment and a worked example.
 
 
 from .BoundedLBFGS import l_bfgs_bounded  # noqa F401
+from .BoundedTRNewtonCG import tr_newton_bounded  # noqa F401
 from .CCGWithoutRestart import constrained_conjugate_gradients  # noqa F401
 from .CCGWithRestart import \
     constrained_conjugate_gradients_with_restart  # noqa F401

--- a/test/Optimization/test_bounded_tr_newton.py
+++ b/test/Optimization/test_bounded_tr_newton.py
@@ -209,6 +209,47 @@ def test_accuracy_hooks_rescue_noisy_objective():
     np.testing.assert_allclose(res.x, x_true, atol=1e-4)
 
 
+def test_accuracy_hooks_stop_retrying_at_floor():
+    """A caller that cannot improve its accuracy (e.g. the attainable
+    residual of a single-precision solve) must not be asked over and over:
+    after one fruitless request per iteration the driver proceeds with the
+    best available accuracy instead of burning max_accuracy_retries
+    re-evaluation rounds."""
+    rng = np.random.default_rng(8)
+    N = 32
+    y = rng.normal(size=N) * 0.3
+
+    state = {"requests": 0, "evals": 0}
+    floor = 1e-3  # irreducible noise level
+
+    def fun_grad(x):
+        state["evals"] += 1
+        d = x - y
+        f = 0.5 * float(np.sum(d * d))
+        return f + floor * np.sin(1e3 * float(np.sum(x))), d
+
+    def hessp(x, v):
+        return v
+
+    def fun_error():
+        return floor  # never improves
+
+    def request_accuracy(target):
+        state["requests"] += 1  # honoured but futile
+
+    res = tr_newton_bounded(
+        fun_grad, np.zeros(N), hessp, jac=True, gtol=1e-6, maxiter=50,
+        delta_max=10.0,
+        fun_error=fun_error, request_accuracy=request_accuracy,
+    )
+
+    # At most one futile request per outer iteration (the stagnation break),
+    # not max_accuracy_retries of them.
+    assert state["requests"] <= res.nit + 1
+    # And the run terminates (converged or not) rather than looping.
+    assert res.nit <= 50
+
+
 def test_callback_and_histories():
     """Callback fires per accepted iterate; diagnostics are recorded."""
     rng = np.random.default_rng(7)

--- a/test/Optimization/test_bounded_tr_newton.py
+++ b/test/Optimization/test_bounded_tr_newton.py
@@ -1,0 +1,293 @@
+#
+# Copyright 2026 Lars Pastewka
+#
+# ### MIT license
+#
+
+import numpy as np
+
+from NuMPI.Optimization import l_bfgs_bounded, tr_newton_bounded
+from NuMPI.Testing.Assertions import assert_all_allclose, parallel_assert
+from NuMPI.Tools import Reduction
+
+# ----------------------------------------------------------------------------
+# Analytic ground truths.
+#
+# Convex quadratic 0.5 sum(w_i (x_i - y_i)^2) on a box: minimiser is
+# clip(y, lo, hi), and hessp is the diagonal map v -> w*v.
+#
+# Indefinite diagonal quadratic 0.5 sum(d_i x_i^2) - g_i x_i on [-1, 1]:
+# for d_i > 0 the minimiser is clip(g_i/d_i, -1, 1); for d_i < 0 the
+# one-dimensional problem is concave, so the minimiser sits at the box
+# endpoint sign(g_i) (f(1) - f(-1) = -2 g_i). This exercises the Steihaug
+# negative-curvature exit and the free-set handling together.
+# ----------------------------------------------------------------------------
+
+
+def _quad(y, w=1.0):
+    def fun_grad(x):
+        d = x - y
+        return 0.5 * float(np.sum(w * d * d)), w * d
+
+    def hessp(x, v):
+        return w * v
+
+    return fun_grad, hessp
+
+
+def _indefinite(diag, g):
+    def fun_grad(x):
+        return float(np.sum(0.5 * diag * x * x - g * x)), diag * x - g
+
+    def hessp(x, v):
+        return diag * v
+
+    return fun_grad, hessp
+
+
+def _indefinite_minimiser(diag, g):
+    x = np.where(diag > 0, np.clip(g / np.where(diag > 0, diag, 1.0), -1, 1),
+                 np.sign(g))
+    # d_i < 0 and g_i == 0: both endpoints tie; pick +1 (any is optimal).
+    x = np.where((diag < 0) & (g == 0), 1.0, x)
+    return x
+
+
+def test_unbounded_quadratic():
+    """Convex quadratic without bounds: exact Newton model, so the first
+    interior Steihaug solve is the Newton step and convergence is immediate."""
+    rng = np.random.default_rng(0)
+    N = 64
+    y = rng.normal(size=N)
+    fun_grad, hessp = _quad(y)
+
+    res = tr_newton_bounded(fun_grad, np.zeros(N), hessp, jac=True,
+                            gtol=1e-10, delta_max=10.0)
+
+    assert res.success, res.message
+    np.testing.assert_allclose(res.x, y, atol=1e-8)
+    # Quadratic + exact Hessian: a handful of outer iterations at most (the
+    # radius may need to grow from delta0 first).
+    assert res.nit <= 10
+
+
+def test_box_matches_clip():
+    """Box-constrained ill-conditioned quadratic: minimiser is clip(y)."""
+    rng = np.random.default_rng(1)
+    N = 128
+    y = rng.normal(size=N) * 0.6 + 0.3
+    w = np.exp(rng.uniform(0, 6, size=N))  # condition number ~ e^6
+    lo, hi = 0.0, 1.0
+    fun_grad, hessp = _quad(y, w)
+
+    res = tr_newton_bounded(fun_grad, np.full(N, 0.5), hessp, jac=True,
+                            bounds_lo=lo, bounds_hi=hi, gtol=1e-10)
+
+    assert res.success, res.message
+    np.testing.assert_allclose(res.x, np.clip(y, lo, hi), atol=1e-8)
+    assert res.x.min() >= lo - 1e-12
+    assert res.x.max() <= hi + 1e-12
+
+
+def test_negative_curvature():
+    """Indefinite quadratic on [-1, 1]: concave directions must be driven to
+    the box boundary through the Steihaug negative-curvature exit."""
+    rng = np.random.default_rng(2)
+    N = 96
+    diag = rng.uniform(-1.0, 2.0, size=N)
+    diag[np.abs(diag) < 0.1] = 0.5  # keep away from singular
+    g = rng.normal(size=N)
+    fun_grad, hessp = _indefinite(diag, g)
+
+    res = tr_newton_bounded(fun_grad, np.zeros(N), hessp, jac=True,
+                            bounds_lo=-1.0, bounds_hi=1.0, gtol=1e-8,
+                            maxiter=500)
+
+    assert res.success, res.message
+    np.testing.assert_allclose(res.x, _indefinite_minimiser(diag, g),
+                               atol=1e-6)
+
+
+def test_agrees_with_lbfgs():
+    """Same box quadratic through both bounded optimizers -> same minimiser
+    (they share feasible set and convergence measure). The quadratic is
+    ill-conditioned, so L-BFGS gets a tolerance it can actually meet; the
+    Newton model lets the trust region converge much tighter."""
+    rng = np.random.default_rng(3)
+    N = 64
+    y = rng.normal(size=N) * 0.7
+    w = np.exp(rng.uniform(0, 2, size=N))
+    fun_grad, hessp = _quad(y, w)
+    x_true = np.clip(y, -0.5, 0.5)
+
+    res_tr = tr_newton_bounded(fun_grad, np.zeros(N), hessp, jac=True,
+                               bounds_lo=-0.5, bounds_hi=0.5, gtol=1e-10)
+    res_lb = l_bfgs_bounded(fun_grad, np.zeros(N), jac=True,
+                            bounds_lo=-0.5, bounds_hi=0.5, gtol=1e-5)
+
+    assert res_tr.success, res_tr.message
+    assert res_lb.success, res_lb.message
+    np.testing.assert_allclose(res_tr.x, x_true, atol=1e-8)
+    np.testing.assert_allclose(res_lb.x, x_true, atol=1e-4)
+    np.testing.assert_allclose(res_tr.x, res_lb.x, atol=1e-4)
+
+
+def test_zero_mask():
+    """Pinned indices stay exactly zero."""
+    rng = np.random.default_rng(4)
+    N = 64
+    y = rng.normal(size=N)
+    mask = np.zeros(N, dtype=bool)
+    mask[::3] = True
+    fun_grad, hessp = _quad(y)
+
+    res = tr_newton_bounded(fun_grad, np.zeros(N), hessp, jac=True,
+                            zero_mask=mask, gtol=1e-10, delta_max=10.0)
+
+    assert res.success, res.message
+    np.testing.assert_allclose(res.x[mask], 0.0, atol=0.0)
+    np.testing.assert_allclose(res.x[~mask], y[~mask], atol=1e-8)
+
+
+def test_nd_x0():
+    """n-D x0 round-trips: iterate/gradient keep the caller's shape."""
+    rng = np.random.default_rng(5)
+    shape = (8, 8)
+    y = rng.normal(size=shape)
+    fun_grad, hessp = _quad(y)
+
+    res = tr_newton_bounded(fun_grad, np.zeros(shape), hessp, jac=True,
+                            gtol=1e-10, delta_max=10.0)
+
+    assert res.success, res.message
+    assert res.x.shape == shape
+    assert res.jac.shape == shape
+    np.testing.assert_allclose(res.x, y, atol=1e-8)
+
+
+def test_accuracy_hooks_rescue_noisy_objective():
+    """Synthetic 'truncated inner solve': the objective carries a
+    deterministic O(noise_amp) perturbation, `fun_error` reports the bound
+    and `request_accuracy` tightens it. The hooks must (a) be exercised and
+    (b) let the run converge to the true minimiser despite an initial noise
+    level far above gtol."""
+    rng = np.random.default_rng(6)
+    N = 64
+    y = rng.normal(size=N) * 0.4
+    w = np.exp(rng.uniform(0, 2, size=N))
+
+    state = {"amp": 1e-1, "requests": 0}
+
+    def fun_grad(x):
+        d = x - y
+        f = 0.5 * float(np.sum(w * d * d))
+        # Deterministic pseudo-noise, O(amp) in f and in the gradient --
+        # mimics the error of a truncated state solve.
+        f_noise = state["amp"] * np.sin(1e3 * float(np.sum(x)))
+        g_noise = state["amp"] * np.sin(1e3 * x + 1.0)
+        return f + f_noise, w * d + g_noise
+
+    def hessp(x, v):
+        return w * v
+
+    def fun_error():
+        return state["amp"]
+
+    def request_accuracy(target):
+        state["requests"] += 1
+        state["amp"] = min(state["amp"], 0.5 * target)
+
+    res = tr_newton_bounded(
+        fun_grad, np.zeros(N), hessp, jac=True,
+        bounds_lo=-1.0, bounds_hi=1.0, gtol=1e-6, maxiter=500,
+        fun_error=fun_error, request_accuracy=request_accuracy,
+    )
+
+    assert state["requests"] > 0  # the control loop actually fired
+    assert res.success, res.message
+    x_true = np.clip(y, -1.0, 1.0)
+    np.testing.assert_allclose(res.x, x_true, atol=1e-4)
+
+
+def test_callback_and_histories():
+    """Callback fires per accepted iterate; diagnostics are recorded."""
+    rng = np.random.default_rng(7)
+    N = 32
+    y = rng.normal(size=N)
+    fun_grad, hessp = _quad(y)
+
+    iterates = []
+    res = tr_newton_bounded(fun_grad, np.zeros(N), hessp, jac=True,
+                            gtol=1e-10, delta_max=10.0,
+                            callback=lambda x: iterates.append(x.copy()))
+
+    assert res.success
+    assert len(iterates) >= 1
+    assert len(res.delta_history) == len(res.rho_history)
+    assert res.nb_hessp > 0
+
+
+# ----------------------------------------------------------------------------
+# MPI-aware tests: per-rank slices, globally reduced scalar f.
+# ----------------------------------------------------------------------------
+
+
+def _distribute(global_arr, comm):
+    size = comm.Get_size()
+    rank = comm.Get_rank()
+    return np.array_split(global_arr, size)[rank]
+
+
+def test_mpi_box(comm):
+    """Distributed box-constrained quadratic; oracle is the local slice of
+    clip(y, lo, hi)."""
+    pnp = Reduction(comm)
+    N_global = 256
+    rng = np.random.default_rng(0)
+    y_global = rng.normal(size=N_global) * 0.6 + 0.3
+    w_global = np.exp(rng.uniform(0, 4, size=N_global))
+    lo, hi = 0.0, 1.0
+
+    y = _distribute(y_global, comm)
+    w = _distribute(w_global, comm)
+
+    def fun_grad(x):
+        d = x - y
+        return pnp.sum(0.5 * w * d * d).item(), w * d
+
+    def hessp(x, v):
+        return w * v
+
+    res = tr_newton_bounded(fun_grad, np.full_like(y, 0.5), hessp, jac=True,
+                            bounds_lo=lo, bounds_hi=hi, comm=comm,
+                            gtol=1e-10)
+
+    parallel_assert(comm, res.success, res.message)
+    assert_all_allclose(comm, res.x, np.clip(y, lo, hi), atol=1e-8)
+
+
+def test_mpi_negative_curvature(comm):
+    """Distributed indefinite quadratic on [-1, 1]."""
+    pnp = Reduction(comm)
+    N_global = 192
+    rng = np.random.default_rng(1)
+    diag_global = rng.uniform(-1.0, 2.0, size=N_global)
+    diag_global[np.abs(diag_global) < 0.1] = 0.5
+    g_global = rng.normal(size=N_global)
+
+    diag = _distribute(diag_global, comm)
+    g = _distribute(g_global, comm)
+
+    def fun_grad(x):
+        return pnp.sum(0.5 * diag * x * x - g * x).item(), diag * x - g
+
+    def hessp(x, v):
+        return diag * v
+
+    res = tr_newton_bounded(fun_grad, np.zeros_like(g), hessp, jac=True,
+                            bounds_lo=-1.0, bounds_hi=1.0, comm=comm,
+                            gtol=1e-8, maxiter=500)
+
+    parallel_assert(comm, res.success, res.message)
+    assert_all_allclose(comm, res.x, _indefinite_minimiser(diag, g),
+                        atol=1e-6)


### PR DESCRIPTION
Adds `tr_newton_bounded`, a bound-constrained **trust-region Newton-CG** optimizer sharing the feasible set (box + `zero_mask`) and convergence measure (∞-norm of the KKT-masked gradient) with `l_bfgs_bounded`.

## Why

For objectives evaluated by **truncated inner solves** (e.g. the FFT-homogenization topology optimization in muTopOpt), a backtracking line search structurally stalls: the Armijo test must resolve decreases that shrink `∝ α` toward zero while the evaluation noise stays constant. The trust-region test compares against the *computable* predicted reduction instead, and the optional `fun_error`/`request_accuracy` hooks enforce the inexact-trust-region condition `|f_err| ≤ eta_f·pred` (Conn–Gould–Toint 2000 ch. 8.4/10.6; Kouri et al. SISC 2013/14), requesting tighter inner accuracy exactly when noise would corrupt acceptance. With the hooks unset it is a classic exact TR method.

## Design

- **Steihaug–Toint truncated CG** on the free subspace, matrix-free `hessp(x, v)` callback; three exits (tolerance / negative curvature / boundary), both sphere intersections evaluated for negative curvature; superlinear forcing `min(0.5, √‖g‖)` by default.
- **Radius logic** follows the muSpectre `SolverTrustRegionNewtonCG` blueprint (shrink ×¼ below ρ=0.25; grow ×2 capped above ρ=0.75 when boundary-limited; accept iff ρ≥η; boundary step never counts as converged), plus the Conn–Gould–Toint round-off safeguard (ρ:=1 when `pred` falls below the floating-point floor of `f`).
- Radius parameterized in **RMS-per-component units** (`Δ_ℓ2 = δ·√N_global`) so the same `delta0`/`delta_max` work at any problem size.
- Same MPI contract as `l_bfgs_bounded` (local slices, globally reduced scalars, all reductions via `pnp`); reuses `_kkt_residual`.

## Tests

`test/Optimization/test_bounded_tr_newton.py`: analytic box quadratics (minimiser = clip), ill-conditioned variant, indefinite quadratic exercising the negative-curvature exit against the analytic box minimiser, `zero_mask`, n-D `x0`, agreement with `l_bfgs_bounded`, callback/diagnostics, synthetic-noise robustness (hooks fire and rescue convergence), and MPI variants. Full suite green serial and `mpirun -np 2`.

**Note**: branched from `26_nd_lbfgs`, so this PR includes its two pending commits (`BUG: Multidimensional x0 in L-BFGS`, `MAINT: Fixed deprecations`) — the TR driver follows the same n-D `x0` convention. Rebase onto master if you land `26_nd_lbfgs` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)