### PR TITLE
Stop CI jobs from hitting the 30-minute timeout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,15 @@ on:
     branches:
       - '**'
 
+# A branch with an open PR triggers BOTH a push and a pull_request run of the
+# full 40-job matrix; ~80 concurrent jobs contend for runners and (with the
+# oversubscribed MPI tests below) can push individual jobs past the timeout.
+# Normalize both event types to one group per branch so the newer run cancels
+# the older duplicate.
+concurrency:
+  group: tests-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-22.04
@@ -66,6 +75,11 @@ jobs:
         run: |
           source venv/bin/activate
           if [ "${{ matrix.mpi }}" == "yes" ]; then
+            # Up to 10 ranks share the runner's ~2 vCPUs: make blocked ranks
+            # yield the CPU instead of busy-wait spinning, which degrades
+            # superlinearly on noisy/oversubscribed VMs and has pushed jobs
+            # past the timeout.
+            export OMPI_MCA_mpi_yield_when_idle=1
             for nbprocs in 1 2 4 8 10; do
               echo "=== $nbprocs MPI processes ==="
               # `coverage run` (parallel mode, set in pyproject.toml) writes a

--- a/test/Optimization/test_projected_lbfgs.py
+++ b/test/Optimization/test_projected_lbfgs.py
@@ -380,7 +380,11 @@ def test_nd_x0_matches_flattened_run():
     V = 1.3
     lo, hi = -0.5, 0.5
 
-    kw = dict(jac=True, gtol=1e-10, maxiter=500, max_halvings=60,
+    # This checks the n-D/flat *identity*, which holds at any iteration
+    # budget -- the problem never reaches gtol, so a large maxiter only burns
+    # CI time (this was the slowest test of the whole suite, ~7 s per rank at
+    # maxiter=500; the runs are compared iterate-for-iterate anyway).
+    kw = dict(jac=True, gtol=1e-10, maxiter=100, max_halvings=60,
               bounds_lo=lo, bounds_hi=hi)
     res_nd = l_bfgs_projected(
         _quad_weighted(y, w), np.zeros(shape), LinearConstraint(a, V), **kw


### PR DESCRIPTION
Tests-workflow jobs have crept from ~4–5 min (historical) to 13–21 min and started getting **cancelled at the 30-minute timeout** (e.g. run 28954823430: killed 28 min in, having finished only 3 of 5 rank-count phases). Diagnosed three compounding causes; one fix each:

## 1. Push + PR double-triggering (workflow)
A branch with an open PR runs the full 40-job matrix **twice** (~80 concurrent jobs). Added a `concurrency` group normalized to the branch name across both event types, `cancel-in-progress: true` — the newer run cancels the duplicate.

## 2. Oversubscribed busy-waiting (workflow)
The MPI step runs up to **10 ranks `--oversubscribe`** on ~2-vCPU runners with OpenMPI's default busy-wait progression, which degrades superlinearly on noisy VMs — measured: the *same matrix cell on the same commit* took **9.5 min** in one run and **>30 min** in a concurrent one. Set `OMPI_MCA_mpi_yield_when_idle=1` so blocked ranks yield the CPU.

## 3. One pathologically slow test (pre-existing since #89)
`test_projected_lbfgs::test_nd_x0_matches_flattened_run` was the slowest test of the whole suite at **~7 s per rank per rank-count phase** (×5 phases ×N ranks): it never reaches its `gtol=1e-10` and burned the full `maxiter=500` twice — although the n-D/flat identity it asserts holds at any iteration budget (verified: identical assertions pass at maxiter=100 in 1.4 s). This single test explains most of the 5→13 min baseline jump after #89.

All three verified locally; suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)